### PR TITLE
dnscache: MERGEQUERIES stability and CPU usage fix

### DIFF
--- a/dns_transmit.c
+++ b/dns_transmit.c
@@ -188,19 +188,20 @@ mergefree (struct dns_transmit *d)
     if (merge_enable)
         unregister_inprogress (d);
 
-    /* unregister us from our mater */
+    /* unregister us from our master */
     if (d->master)
     {
         for (i = 0; i < d->master->nslaves; i++)
             if (d->master->slaves[i] == d)
                 d->master->slaves[i] = 0;
+        d->master = 0;
     }
 
     /* and unregister all of our slaves from us */
     for (i = 0; i < d->nslaves; i++)
     {
         if (d->slaves[i])
-            d->slaves[i]->master = NULL;
+            d->slaves[i]->master = 0;
     }
 
     d->nslaves = 0;


### PR DESCRIPTION
This patch resolves the long-standing 100% CPU usage issue with the
MERGEQUERIES patch[1] in our environment.  The CPU usage is just a
symptom; the underlying issue is that the master field in the
dns_transmit struct is not properly reset when mergefree() is called.
This patch is against the ndjbdns source but should be trivial to
transplant to other djbdns-derived sources that include MERGEQUERIES.

When a query becomes a slave query because an identical query is
in-progress, its master field is set to point at the in-progress
query's dns_transmit structure.  When the query is later complete, the
master pointer in the slave query's structure remains intact and so is
set for the next query.  When the struct is later reused for a master
query, calls to dns_transmit_get() return immediately since the master
field is nonzero recv() is never called:

    int
    dns_transmit_get (struct dns_transmit *d, const iopause_fd *x,
                                              const struct taia *when)
    {
        ...
        if (d->tcpstate == 0 && d->master)
            return 0;
        ...
        if (d->tcpstate == 0)
        {
            ...
            r = recv (fd, udpbuf, sizeof (udpbuf), 0);
            ...
        }
        ...
    }

Because recv() is never called, there is always data ready in one of
the fds polled by poll(), so the CPU spins at 100% even while handling
other queries normally.  This bug also means some queries go
unanswered and the data sits in the UDP receive queue.  In fact, we
started investigating due to these unanswered queries.

I think this patch will resolve the issue reported in a Red Hat bug
report[2] and perhaps fix an issue reported against the ndjbdns
project[3].  I will report to those sites as well.

I also fixed a misspelling and a consistency nit in the surrounding
code.

References:
  [1] MERGEQUERIES patch: http://marc.info/?l=djbdns&m=123859517723684
  [2] Red Hat bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1084747
  [3] ndjbdns Issue: https://github.com/pjps/ndjbdns/issues/23