### PR TITLE
Implementing patch for Akami CNAME recursion issue

### DIFF
--- a/query.c
+++ b/query.c
@@ -275,7 +275,7 @@ doit (struct query *z, int state)
 
 
 NEWNAME:
-    if (++z->loop == 100)
+    if (++z->loop == QUERY_MAXLOOP)
         goto DIE;
     d = z->name[z->level];
     dtype = z->level ? DNS_T_A : z->type;
@@ -695,7 +695,7 @@ LOWERLEVEL:
 
 
 HAVEPACKET:
-    if (++z->loop == 100)
+    if (++z->loop == QUERY_MAXLOOP)
         goto DIE;
     buf = z->dt.packet;
     len = z->dt.packetlen;

--- a/query.h
+++ b/query.h
@@ -6,6 +6,7 @@
 #define QUERY_MAXNS 16
 #define QUERY_MAXLEVEL 5
 #define QUERY_MAXALIAS 16
+#define QUERY_MAXLOOP 1000
 
 struct query
 {


### PR DESCRIPTION
From http://marc.info/?l=djbdns&m=113170809226754 - Akami uses a lot of CNAME recursion for their hosted DNS which blows up with (n)djbdns.

I have increased the QUERY_MAXLOOP variable to 1000 from 160 in the patch based on my own testing and from https://blog.yo61.com/djbdns-dnscache-not-resolving-akamai-hosted-domains/