### PR TITLE
Corrected references to README, now that it should be README.md

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -14,7 +14,7 @@ Basic Installation
 
    Briefly, the shell command `./configure && make && make install'
 should configure, build, and install this package.  The following
-more-detailed instructions are generic; see the `README' file for
+more-detailed instructions are generic; see the `README.md' file for
 instructions specific to this package.  Some packages provide this
 `INSTALL' file but do not implement all of the features documented
 below.  The lack of an optional feature in a given package is not
@@ -38,7 +38,7 @@ cache files.
 
    If you need to do unusual things to compile the package, please try
 to figure out how `configure' could check whether to do them, and mail
-diffs or instructions to the address given in the `README' so they can
+diffs or instructions to the address given in the `README.md' so they can
 be considered for the next release.  If you are using the cache, and at
 some point `config.cache' contains results you don't want to keep, you
 may remove or edit it.
@@ -200,7 +200,7 @@ option `--program-prefix=PREFIX' or `--program-suffix=SUFFIX'.
 `configure', where FEATURE indicates an optional part of the package.
 They may also pay attention to `--with-PACKAGE' options, where PACKAGE
 is something like `gnu-as' or `x' (for the X Window System).  The
-`README' should mention any `--enable-' and `--with-' options that the
+`README.md' should mention any `--enable-' and `--with-' options that the
 package recognizes.
 
    For packages that use the X Window System, `configure' can usually

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,7 @@ nodist_man1_MANS = dnsip.1 dnsq.1 dnsfilter.1 djbdns.1 tinydns-data.1 \
 	randomip.1 dnstrace.1 axfr-get.1 dnsname.1 rbldns-data.1
 
 CLEANFILES = $(bin_SCRIPTS) $(nodist_man1_MANS) $(nodist_man8_MANS)
-EXTRA_DIST = dnstracesort.sh readme.ms README INSTALL TODO ChangeLog \
+EXTRA_DIST = dnstracesort.sh readme.ms README.md INSTALL TODO ChangeLog \
 	COPYING $(noinst_MANS) ndjbdns.logrotate
 
 axfrdns_SOURCES = axfrdns.c iopause.c droproot.c tdlookup.c response.c \

--- a/missing
+++ b/missing
@@ -191,7 +191,7 @@ give_advice ()
       ;;
     *)
       echo "You might have modified some files without having the proper"
-      echo "tools for further handling them.  Check the 'README' file, it"
+      echo "tools for further handling them.  Check the 'README.md' file, it"
       echo "often tells you about the needed prerequisites for installing"
       echo "this package.  You may also peek at any GNU archive site, in"
       echo "case some other package contains this missing '$1' program."

--- a/ndjbdns.spec
+++ b/ndjbdns.spec
@@ -189,7 +189,7 @@ fi
 %endif
 
 %files
-%doc README COPYING ChangeLog
+%doc README.md COPYING ChangeLog
 
 %{_sbindir}/axfrdns
 %{_sbindir}/dnscache


### PR DESCRIPTION
Builds currently fail due to an attempt to copy the README file, which no longer exists.