### PR TITLE
dnscache: Fix array overrun under load with MERGEQUERIES

### DIFF
--- a/dns_transmit.c
+++ b/dns_transmit.c
@@ -66,6 +66,8 @@ try_merge (struct dns_transmit *d)
             continue;
         if (!merge_equal(d, inprogress[i]))
             continue;
+        if (inprogress[i]->nslaves == MAXUDP)
+            continue;
 
         d->master = inprogress[i];
         inprogress[i]->slaves[inprogress[i]->nslaves++] = d;
@@ -200,8 +202,10 @@ mergefree (struct dns_transmit *d)
     /* and unregister all of our slaves from us */
     for (i = 0; i < d->nslaves; i++)
     {
-        if (d->slaves[i])
+        if (d->slaves[i]) {
             d->slaves[i]->master = 0;
+            d->slaves[i] = 0;
+        }
     }
 
     d->nslaves = 0;


### PR DESCRIPTION
When MERGEQUERIES is enabled, the slaves array in struct date_transmit
is overrun if a sufficient number of mergable queries arrive before an
answer is received or a query timeout occurs.

The fix is to add a missing bounds check in try_merge().  Without this
check, try_merge() can update an in-progress query's nslaves beyond
MAXUDP and then write to that location in its slave array, clobbering
nslaves (next in the struct) and other data after it in memory.  With
the bounds check, try_merge will simply continue its search with the
next in-progress query.

The symptom of this bug in my environment is a segfault when
mergefree() iterates over a master's slaves and the master's nslaves
field had been overwritten with a pointer to another dns_transmit
structure, causing the loop to iterate much higher than MAXUDP.
Eventually it tries to read an invalid memory area.

This patch also resets slaves array pointers to 0 in mergefree(),
which should cause no functional change but helps make core dumps
easier to reason about.